### PR TITLE
Setting pet-battle front version to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pet-battle",
-  "version": "1.3.1",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
Set version 1.2.0 for front of pet-battle application to align with the documentation and separate versions between front and api.

Front (pet-battle): 1.2.0
API (pet-battle-api): 1.3.1

