### PR TITLE
Show application version in front

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pet-battle",
-  "version": "1.3.1",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "ng": "ng",

--- a/src/app/shell/header/header.component.html
+++ b/src/app/shell/header/header.component.html
@@ -6,7 +6,7 @@
     <!-- <nav class="navbar  navbar-expand-lg navbar-dark" style="background-color: #E00201;"> -->
     <!-- Green #009B00 -->
     <!-- <nav class="navbar  navbar-expand-lg navbar-dark" style="background-color: #009B00;"> -->
-    <a class="navbar-brand" href="/home">Pet Battle</a>
+    <a class="navbar-brand" href="/home">Pet Battle {{ appVersion }}</a>
     <button
       class="navbar-toggler"
       type="button"

--- a/src/app/shell/header/header.component.ts
+++ b/src/app/shell/header/header.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { KeycloakService } from 'keycloak-angular';
+import * as packageJson from '../../../../package.json';
 
 @Component({
   selector: 'app-header',
@@ -11,6 +12,7 @@ export class HeaderComponent implements OnInit {
   menuHidden = true;
   buttonText: string;
   isLoggedIn: boolean;
+  appVersion: string = packageJson.version;
 
   constructor(private readonly keycloakSvc: KeycloakService, private router: Router) {
     this.keycloakSvc.isLoggedIn().then(isLoggedIn => {


### PR DESCRIPTION
The Pet Battle application doesn't include a simple an easy way to identify the current version deployed from the PoV of the user. This behaviour could be tricky in some labs (e.g: Blue/Green deployment) when you have different versions of the application and you want to check easily which version you are using.

This PR includes a simple (very simple and maybe not so pretty) to show in the nav bar the current version of the frontend of the application. The idea is to have a very simple mechanism to identify which version of the frontend we are browsing.

This feature could help in other labs adding some screenshots to follow easily the instructions or the expected results.
